### PR TITLE
Frontend 120 announcements page outline

### DIFF
--- a/app/components/AnnouncementList.tsx
+++ b/app/components/AnnouncementList.tsx
@@ -1,47 +1,164 @@
 import Announcement from "../components/announcements";
 import { FC } from "react";
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
+import Pagination from '@mui/material/Pagination';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import Button from '@mui/material/Button';
+import SearchIcon from '@mui/icons-material/Search';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputBase from '@mui/material/InputBase';
+// import AnnouncementsModalButton from './AnnouncementsModalButton';
+import { profileData } from './types';
+import theme from '../theme';
+import ClearIcon from '@mui/icons-material/Clear';
+import Add from "../images/9.png"
+import Image from "next/image";
 
 const AnnouncementList: FC = () => {
+
   return (
+    <Box
+      sx={{
+        display: 'flex',
+        minHeight: '90vh',
+        flexDirection: 'column',
+        justifyContent: 'flex-start',
+        borderRadius: '5%',
+        backgroundColor: '#f6f6f6',
+        fontFamily: 'default',
+        margin: '2%',
+        marginLeft: '5%',
+        marginRight: '5%',
+        padding: '3%'
+      }}
+    >
+      <Stack spacing={10}>
+        {/* Header content */}
+        <Stack spacing={2}>
+          <Grid container spacing={3} columns={20} columnSpacing={{xs: 20, sm:80, md:5, lg:5}} margin={10} paddingTop='5%'>
+                {/* Left side of header */}
+                <Grid xs={13}>
+                  {/* Page Title */}
+                  <Typography variant="h1" sx={{fontWeight: 'bold', paddingBottom:'10%'}}>
+                      Announcements
+                  </Typography>
 
-    <div>
-      {/* Pass arguments to Announcemnet Component*/}
-      <div style={{ paddingBottom: 10 }}>
-        <Announcement
-          imageUrl="imageUrl"
-          senderName="SenderNameThatIsTooLong"
-          messageTitle="This is a sample announement title"
-          date="1/12/23"
-        />
-      </div>
+                  {/* Search Bar */}
+                  <Grid container spacing={3} columns={4}>
+                    {/* Actual Search Bar */}
+                    <Grid xs={3}>
+                      <InputBase 
+                        fullWidth
+                        endAdornment={
+                          <InputAdornment position="end">
+                            <SearchIcon />
+                          </InputAdornment>
+                        }
+                        sx={{
+                          backgroundColor: '#FFFFFF',
+                          borderRadius: '10px',
+                          padding: '3px',
+                          paddingLeft: '20px',
+                          paddingRight: '10px',
+                        }}
+                      />
+                    </Grid>
+                    {/* Search Button */}
+                    <Grid xs={1}>
+                      <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor: theme.palette.primary.main}, textTransform: 'none'}} variant="contained">search</Button>
+                    </Grid>
+                  </Grid>
+                </Grid>
 
-      <div style={{ paddingBottom: 10 }}>
-        <Announcement
-          imageUrl="imageUrl"
-          senderName="Carly"
-          messageTitle="message Title That Is Way Too Loooooooong"
-          date="4/5/16"
-        />
-      </div>
+                {/* Right side of header */}
+                <Grid xs={7}>
+                  {/* Add new announcement */}
+                  <Grid container>
+                     {/* <AddEmployeeModal profiles={peopleArray} onUpdate={setPeopleArray}/>  */}
+                    <Button fullWidth variant="outlined" sx={{ padding: '3%', borderRadius: '25px', borderColor: "#57228F", backgroundColor: '#FFFFFF', color: "#000000", '&:hover': { borderColor: theme.palette.primary.main }, textTransform: 'none', display: 'flex', alignItems: 'center' }}> 
+                      <div fullWidth style={{ paddingRight: '35px' }}>Add New Announcement</div>
+                      <Image src={Add} alt="Error" width={30} height={30} />
+                    </Button>
+                  </Grid>
 
-      <div style={{ paddingBottom: 10 }}>
-        <Announcement
-          imageUrl="imageUrl"
-          senderName="Casa Myrna"
-          messageTitle="short title"
-          date="12/10/23"
-        />
-      </div>
+                  {/* Select filters */}
+                  <Grid container spacing={2} columns={3} paddingTop={'16%'}>
+                    <Grid xs={2}>
+                      <Select
+                        fullWidth
+                        value="" // Set the initial value to an empty string
+                        displayEmpty // Display the selected value even when it's empty
+                        sx={{ backgroundColor: '#FFFFFF', borderRadius: '10px', height: '38px'}}
+                      >
+                        <MenuItem value="" disabled>
+                          Select filters
+                        </MenuItem>
+                        {/* Add more MenuItem components with filter options here */}
+                      </Select>
+                    </Grid>
+                    {/* Filter button */}
+                    <Grid xs={1}>
+                      <Button fullWidth sx={{borderRadius:'15px', backgroundColor:"#89B839", '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">filter</Button>
+                    </Grid>
+                  </Grid>
+                </Grid>
+          </Grid>
 
-      <div style={{ paddingBottom: 10 }}>
-        <Announcement
-          imageUrl="imageUrl"
-          senderName="Taylor Swift"
-          messageTitle="Free Eras Tour Tickets"
-          date="2/20/24"
-        />
-      </div>
-    </div>
+
+          {/* Announcement List */}
+          <div style={{ paddingLeft: '4%' }}>
+            {/* Pass arguments to Announcemnet Component*/}
+            <div style={{ paddingBottom: 10 }}>
+              <Announcement
+                imageUrl="imageUrl"
+                senderName="SenderNameThatIsTooLong"
+                messageTitle="This is a sample announement title"
+                date="1/12/23"
+              />
+            </div>
+
+            <div style={{ paddingBottom: 10 }}>
+              <Announcement
+                imageUrl="imageUrl"
+                senderName="Carly"
+                messageTitle="message Title That Is Way Too Loooooooong"
+                date="4/5/16"
+              />
+            </div>
+
+            <div style={{ paddingBottom: 10 }}>
+              <Announcement
+                imageUrl="imageUrl"
+                senderName="Casa Myrna"
+                messageTitle="short title"
+                date="12/10/23"
+              />
+            </div>
+
+            <div style={{ paddingBottom: 10 }}>
+              <Announcement
+                imageUrl="imageUrl"
+                senderName="Taylor Swift"
+                messageTitle="Free Eras Tour Tickets"
+                date="2/20/24"
+              />
+            </div>
+          </div>
+        </Stack>
+
+        {/* Pagination */}
+        <Stack spacing={2} alignItems="center">
+          <Pagination color="secondary" />
+        </Stack>
+      </Stack>
+    
+    </Box>
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "@fontsource/montserrat": "^5.0.15",
         "@mui/icons-material": "^5.14.15",
         "@mui/material": "^5.14.15",
-        "@prisma/client": "^5.10.2",
         "@mui/system": "^5.15.9",
         "@mui/x-date-pickers": "^6.19.4",
+        "@prisma/client": "^5.10.2",
         "aws-sdk": "^2.1560.0",
         "next": "^13.5.4",
         "next-auth": "^4.23.2",
@@ -2252,6 +2252,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
       "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"


### PR DESCRIPTION
Developers: Jiyoon Choi, Carly Seigel
Dates: 3/4/2024
Time spent: 1 hour

Added announcement page outline

Desktop Testing:
<img width="1439" alt="Screenshot 2024-03-04 at 6 16 05 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/46614509/bfce5098-4434-40e0-9a7e-f8d98ee92cb5">

Reflection: Very straightforward, similar to manage profiles outline. 😁💞