### PR TITLE
Refresh shifts on Calendar when shift is added

### DIFF
--- a/app/components/Calendar.tsx
+++ b/app/components/Calendar.tsx
@@ -77,7 +77,7 @@ const style = {
 const localizer = momentLocalizer(moment);
 const employeeOptions = ["Ana Quieros", "Anna Seifield", "Anne Brown", "Angel Ferrian"];
 
-const MyCalendar = (props: {filters: any}) => {
+const MyCalendar = (props: {filters: any, fetchShiftsTrigger: any, setFetchShiftsTrigger: any}) => {
   const { isSignedIn, user, isLoaded } = useUser();
 
   // TODO: start of modal logic - abstract away into a different component (CalendarModalButton)
@@ -87,7 +87,7 @@ const MyCalendar = (props: {filters: any}) => {
 
 
   const [formData, setFormData] = useState<CalendarInfo | null>(null);
-  const [fetchShiftsTrigger, setFetchShiftsTrigger] = useState(0);
+  // const [fetchShiftsTrigger, setFetchShiftsTrigger] = useState(0);
 
   const [open, setOpen] = useState(false);
   const today = new Date();
@@ -118,7 +118,7 @@ const MyCalendar = (props: {filters: any}) => {
         throw new Error('Failed to fetch shift data');
       }
     })();
-  }, [fetchShiftsTrigger])
+  }, [props.fetchShiftsTrigger])
   
 
   // const shifts = shiftInfo?.map((shift: CalendarInfo, _) => {
@@ -274,7 +274,8 @@ const MyCalendar = (props: {filters: any}) => {
       },
       body: JSON.stringify(formData)
     });
-    setFetchShiftsTrigger(prev => prev + 1);
+    console.log("Before setfetchShiftsTrigger")
+    props.setFetchShiftsTrigger(Date.now());
     handleClose()
   }
 
@@ -381,7 +382,7 @@ const MyCalendar = (props: {filters: any}) => {
 };
 
 const calendar = () => {
-
+  const [fetchShiftsTrigger, setFetchShiftsTrigger] = useState(0);
   const [filterState, setFilter] = React.useState({
     partTime: true,
     fullTime: true,
@@ -465,7 +466,7 @@ const calendar = () => {
         </Grid>
 
         <Grid xs={5} paddingTop="8%">
-          <CalendarModalButton/>
+          <CalendarModalButton callback={setFetchShiftsTrigger}/>
           <FormControl sx={{ m: 1, minWidth: 160 }}>
             <InputLabel htmlFor="grouped-select">Choose Filters</InputLabel>
               {/* Menu props align the popup */}
@@ -548,7 +549,7 @@ const calendar = () => {
       </Grid>
 
       <Grid paddingBottom={'4%'}>
-        <MyCalendar filters={filterState}/>
+        <MyCalendar filters={filterState} fetchShiftsTrigger={fetchShiftsTrigger} setFetchShiftsTrigger={setFetchShiftsTrigger}/>
       </Grid>
     </Box>
   );

--- a/app/components/CalendarModalButton.tsx
+++ b/app/components/CalendarModalButton.tsx
@@ -69,19 +69,11 @@ const initialFormData = {
     phoneLine: ''
 };
 
-const CalendarModalButton: FC = () => {    
+const CalendarModalButton: FC <any> = ({callback}) => {    
     const [open, setOpen] = useState(false);
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
-
-
-    // const initialFormData = {
-
-    //     phoneLine: '',
-    //     startTime: '',
-    //     endTime: '',
-    //     assignedEmployee: '',
-    // };
+w
 
     const [startDate, setStartDate] = useState(new Date());
     const [endDate, setEndDate] = useState(new Date());
@@ -145,6 +137,7 @@ const CalendarModalButton: FC = () => {
 
             // Reset form data after successful submission
             setFormData(initialFormData);
+            callback(Date.now())
             handleClose();
         } catch (error) {
             console.error('Error assigning shift:', error);


### PR DESCRIPTION
Coders: Sean and Naomi 
Date: March 30th, 2024 
Description: 
We were able to make it so that the calendar automatically refreshes when adding one or multiple shifts. We didn't have too many issues, mostly just trying to figure out how to make sure that this refreshes and reaches multiple parts of the calendar. We did have a small issue with adding multiple shifts, but were able to persevere and make it work! The only small issue is that if someone tries to add multiple shifts in the same second, it won't work, but this should not even be physically possible. 
