### PR TITLE
Split overnight shifts into two events

### DIFF
--- a/app/components/Calendar.tsx
+++ b/app/components/Calendar.tsx
@@ -219,8 +219,37 @@ const MyCalendar = (props: {filters: any, fetchShiftsTrigger: any, setFetchShift
     }
   });
 
+  /* 
+   * splits shifts that occur over two days into two different events so that
+   * they're rendered correctly on the calendar
+   */
+  const splitOvernightShifts = (shiftsArray: any): any => {
+    
+    if (!shiftsArray) return []
+
+    let updatedShifts = []
+
+    for (let shift of shiftsArray) {
+      const isOvernight = shift.start.getDate() !== shift.end.getDate()
+      if (isOvernight) {
+          let shift1 = {...shift, end: new Date(shift.start)};
+          let shift2 = {...shift, start: new Date(shift.end)};
+          
+          shift1.end.setHours(23, 59, 59, 999)
+          shift2.start.setHours(0, 0, 0, 0)
+      
+          updatedShifts.push(shift1)
+          updatedShifts.push(shift2)
+      } else {
+        updatedShifts.push(shift)
+      }
+    }
+    return updatedShifts
+   
+  }
+
   // this is to tell typescript that if the array is undefined, then use the empty list instead
-  const events = [...shifts ?? [], ...onCallShifts ?? []]
+  const events = [...splitOvernightShifts(shifts) ?? [], ...onCallShifts ?? []]
 
   const handleOpen = (e: CalendarInfo) => {
     setOpen(true);
@@ -440,9 +469,6 @@ const calendar = () => {
     }
   };
   
-  
-  
-
   return (
     <Box
       sx={{


### PR DESCRIPTION
Sean Reilly & David Chen
Time Spent: 2 hours

Splits normal shifts that span two days into two different events so that they don't look like on-call shifts on the Calendar. Ex. If a shift is from 10:00 PM Friday - 3:00 AM Saturday it will be split into two events, one 10:00 PM - 11:59 Friday and one 12:00 AM Saturday - 3:00 AM Saturday.
Note: This will not work for shifts that span 3 or more days 

Testing: 

Scheduling a shift:
<img width="1435" alt="Screenshot 2024-04-07 at 1 36 08 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/84764829/5b182837-43e2-4048-a557-4b984a96aabb">

Here are the two segments:
<img width="926" alt="Screenshot 2024-04-07 at 1 36 21 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/84764829/cd09c19f-3d32-49b4-9648-b755bc78415c">
<img width="930" alt="Screenshot 2024-04-07 at 1 37 22 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/84764829/404719cb-b967-43a5-b610-e6c0c891f114">

Modifying one part of the shift, such as by clicking on it and cancelling it, will also modify the other part
