### PR TITLE
Fullstack 131 calendar add unassigned shift

### DIFF
--- a/app/components/CalendarModalButton.tsx
+++ b/app/components/CalendarModalButton.tsx
@@ -116,7 +116,7 @@ const CalendarModalButton: FC <any> = ({callback}) => {
             created_at: createdAt,
             userID: "2",
             message: 'hello',
-            status: firstName === '' && lastName === '' ? 'PENDING' : 'ACCEPTED',
+            status: firstName === '' && lastName === '' ? 'CANCELLED' : 'ACCEPTED',
             onCallShiftID: 1
         };
 
@@ -187,7 +187,7 @@ const CalendarModalButton: FC <any> = ({callback}) => {
                 <Grid container spacing={4}  direction='column' alignItems='flex-start'  paddingBottom='13%'>
                     <Grid container direction="row" justifyContent={'flex-end'} xs ={12} sm={12} md={12} lg={12}sx={{marginTop: '20px', marginLeft: '-130px' }}>
                         <Typography variant="h4"  sx={{marginTop: '15px', marginRight: '10px'}}>
-                        Start Time: 
+                            Start Time: <span style={{ color: 'red' }}>*</span>
                         </Typography>
 
                         {/* Start Date */}
@@ -203,6 +203,7 @@ const CalendarModalButton: FC <any> = ({callback}) => {
                             name="startTime"
                             value={formData.startTime}
                             onChange={handleInputChange}
+                            required
                             sx={{ borderRadius: '10px',  width: "190px", backgroundColor: "#FFFFFF", outlineColor: "#000000", height: '56px'}}
                         >
                         <MenuItem value={0}>12:00 am</MenuItem>
@@ -232,8 +233,8 @@ const CalendarModalButton: FC <any> = ({callback}) => {
                     </Select>
                     </Grid>
                     <Grid container direction="row" xs ={12} sm={12} md={12} lg={12} sx={{marginTop: '18px', marginLeft: '-130px', justifyContent: 'flex-end' }}>
-                        <Typography variant="h4" sx={{marginTop: '15px', marginRight: '10px' }}>
-                        End Time: 
+                        <Typography variant="h4" sx={{marginTop: '15px', marginRight: '14px' }}>
+                        End Time: <span style={{ color: 'red' }}>*</span>
                         </Typography>
                         <LocalizationProvider dateAdapter={AdapterDayjs}>
                             <div component={['DatePicker']} >
@@ -249,6 +250,7 @@ const CalendarModalButton: FC <any> = ({callback}) => {
                             name="endTime"
                             value={formData.endTime}
                             onChange={handleInputChange}
+                            required
                             sx={{ borderRadius: '10px',  width: "190px", backgroundColor: "#FFFFFF", outlineColor: "#000000", height: '56px'}}
                         >
                             <MenuItem value={0}>12:00 am</MenuItem>
@@ -278,7 +280,7 @@ const CalendarModalButton: FC <any> = ({callback}) => {
                         </Select>
                     </Grid>
                     <Grid container direction="row" xs ={12} sm={12} md={12} lg={12}sx={{ marginTop: '18px', marginLeft: '-130px', justifyContent: 'flex-end' }}>
-                        <Typography variant="h4" sx={{ marginTop: '15px', marginRight: '114px' }}>
+                        <Typography variant="h4" sx={{ marginTop: '15px', marginRight: '130px' }}>
                         Assigned Employee: 
                         </Typography>
                         <Select
@@ -292,13 +294,14 @@ const CalendarModalButton: FC <any> = ({callback}) => {
                     </Select>
                     </Grid>
                     <Grid container direction="row" xs ={12} sm={12} md={12} lg={12}sx={{ marginTop: '18px', marginLeft: '-130px', justifyContent: 'flex-end' }}>
-                        <Typography variant="h4" sx={{ marginTop: '15px',marginRight: '182px' }}>
-                        Phone Line: 
+                        <Typography variant="h4" sx={{ marginTop: '15px', marginRight: '185px' }}>
+                        Phone Line: <span style={{ color: 'red' }}>*</span>
                         </Typography>
                             <Select
                             name="phoneLine"
                             value={formData.phoneLine}
                             onChange={handleInputChange}
+                            required
                             sx={{ borderRadius: '10px',  width: "190px", backgroundColor: "#FFFFFF", outlineColor: "#000000", height: '56px'}}
                             >
                             <MenuItem value={'1'}>1</MenuItem>


### PR DESCRIPTION
Developers: Jiyoon and Eliana
Dates: 4/5, 4/7
Time spent: 2 hours
Summary: Allowed adding an unassigned shift to the Calendar via the Calendar modal. New unassigned shifts are defaulted to be cancelled. Also added red asterisks indicating the required fields so that the user knows which fields need inputs.

Testing:
<img width="1440" alt="Screenshot 2024-04-07 at 2 13 35 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/46614509/7f1d7aa3-862d-405e-903e-f511e889e015">
<img width="1435" alt="Screenshot 2024-04-07 at 2 13 28 PM" src="https://github.com/elizabethfoster02/casa-myrna/assets/46614509/027366d0-45b7-4cda-83ad-70b51bf82588">
