### PR TITLE
Grey-ed out non-editable text fields in the profile page

### DIFF
--- a/app/components/MyProfile.tsx
+++ b/app/components/MyProfile.tsx
@@ -307,7 +307,7 @@ const handleDeleteProfilePicture = async () => {
                 disableUnderline: true,
                 style: { paddingLeft: 8 },
               }}
-              sx={{ backgroundColor: "#FFFFFF", borderRadius: "10px" }}
+              sx={{ backgroundColor: "#EEEEEE", borderRadius: "10px" }}
               id="outlined-basic"
               label=""
               variant="standard"
@@ -359,7 +359,7 @@ const handleDeleteProfilePicture = async () => {
                 disableUnderline: true,
                 style: { paddingLeft: 8 },
               }}
-              sx={{ backgroundColor: "#FFFFFF", borderRadius: "10px" }}
+              sx={{ backgroundColor: "#EEEEEE", borderRadius: "10px" }}
               id="outlined-basic"
               label=""
               variant="standard"
@@ -384,7 +384,7 @@ const handleDeleteProfilePicture = async () => {
                 disableUnderline: true,
                 style: { paddingLeft: 8 },
               }}
-              sx={{ backgroundColor: "#FFFFFF", borderRadius: "10px" }}
+              sx={{ backgroundColor: "#EEEEEE", borderRadius: "10px" }}
               id="outlined-basic"
               label=""
               variant="standard"
@@ -405,7 +405,7 @@ const handleDeleteProfilePicture = async () => {
                 disableUnderline: true,
                 style: { paddingLeft: 8 },
               }}
-              sx={{ backgroundColor: "#FFFFFF", borderRadius: "10px" }}
+              sx={{ backgroundColor: "#EEEEEE", borderRadius: "10px"}}
               id="outlined-basic"
               label=""
               variant="standard"
@@ -420,7 +420,7 @@ const handleDeleteProfilePicture = async () => {
                 disableUnderline: true,
                 style: { paddingLeft: 8 },
               }}
-              sx={{ backgroundColor: "#FFFFFF", borderRadius: "10px" }}
+              sx={{ backgroundColor: "#EEEEEE", borderRadius: "10px" }}
               id="outlined-basic"
               label=""
               variant="standard"


### PR DESCRIPTION
Developer: Pam and Naomi
Dates: April 13th 2024
Time spent: 1 hour
Summary: Made non-editable text fields in the MyProfile page grey, and left editable pronouns field White.

Testing Desktop:
![image](https://github.com/JumboCode/casa-myrna/assets/79951993/e7767760-ec38-422d-8544-1acf926110ce)

Testing Mobile:
![image](https://github.com/JumboCode/casa-myrna/assets/79951993/b4bba1c7-e35d-4437-9e44-537036d9d7bc)



Reflection: Straightforward ticket, the pronouns button does not work but was not specified in our ticket to make it work.