### PR TITLE
Fullstack #3 Pagination

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest) {
       queryFilters["emailAddress"] = [email]
     }
     try {
-      const users = await clerkClient.users.getUserList(queryFilters);
+      const users = await clerkClient.users.getUserList({queryFilters, limit: 500});
       return Response.json(users)
     } catch {
       return new Response('Error: user not found', {


### PR DESCRIPTION
Developer: Jiyoon and Pam
Dates: April 18
Time spent: 30 min

Summary: The Manage Profiles page now pulls all users instead of the current 10 from the DB.

Testing:
<img width="1436" alt="Screenshot 2024-04-18 at 9 07 54 PM" src="https://github.com/JumboCode/casa-myrna/assets/46614509/c7073720-c62c-4be1-bef9-f531f5d57824">
<img width="1440" alt="Screenshot 2024-04-18 at 9 08 02 PM" src="https://github.com/JumboCode/casa-myrna/assets/46614509/fe993a84-d128-4c44-bee5-9b07c356bb14">


Reflection: This ticket originally had us stumped, until we asked the group chat for help and David said he actually already fixed this bug but it got lost in the merges (his ticket was Fullstack #118). 
