### PR TITLE
Re-arranged Grid on Add new Employee Modal for natural *tab* progression

### DIFF
--- a/app/components/AddEmployeeModal.tsx
+++ b/app/components/AddEmployeeModal.tsx
@@ -159,7 +159,7 @@ return (
             open={open}
             onClose={handleClose}>
         {/* Gray Modal Box */}
-        <Box sx={style}>
+          <Box sx={style}>
             {/* Button Box */}
             <Box sx={{width: 50, height: 50, position: 'absolute', right: '5%', fill:'none'}}>
                 <button 
@@ -175,118 +175,149 @@ return (
                 </Typography>
             </Box>
             <Box>
-        <form onSubmit={handleSubmit}>
-        <Grid container spacing={5} columnSpacing={{xs: 10, sm:80, md:5, lg:5}} justify-content='flex-start' alignItems='flex-start' columns={12}  margin={{xs: 1, sm: 2, md: 3, lg: 4}}>
-           <Grid container spacing={4} direction='column' justifyContent='flex-start' alignItems='flex-start'>
-                <Grid xs={12} sm={12} md={12} lg={12} sx={{ justifyContent:'flex-start', alignItems:'flex-start', display: 'flex'}}>
-                    <Avatar alt="Remy Sharp" sx={{ width: 150, height: 150 }} />
-                </Grid>
-                <Grid xs={12} sm={12} md={12} lg={12} textAlign={'center'}>
-    
-                    <Button variant="outlined" sx={{ textIndent: '2px' ,borderRadius: '20px',  borderColor: theme.palette.primary.main, color: "#000000", '&:hover': {borderColor: theme.palette.primary.main}, textTransform: 'none', paddingRight: '10%'}}>
-                        <Image src={UploadImage} alt="upload image" width={17} height={17} />
-                        Upload Picture
-                    </Button>
-                    
-                </Grid>
-            </Grid>
-            {/* This is column 1 */}
-            <Grid container spacing={4} direction='column' alignItems='flex-center'>
-                <Grid xs ={12} sm={12} md={12} lg={12} justifyContent ={'flex-start'}>
-                   <Typography variant="h4">
-                        First Name
-                    </Typography>
-                    <TextField 
-                        name="firstName"
-                        value={formData.firstName}
-                        onChange={handleInputChange} 
-                        InputProps={{disableUnderline: true, style: {paddingLeft: 8} }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
-                        variant="standard"
-                        required/>
-                </Grid>
-                <Grid direction='row' xs ={12} sm={12} md={12} lg={12}>
-                    <Typography variant="h4" >
-                        Pronouns
-                    </Typography>
-                    <TextField
-                    name="pronouns"
-                    value={formData.pronouns}
-                    onChange={handleInputChange} 
-                    InputProps={{disableUnderline: true, style: {paddingLeft: 8}}} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
-                    variant="standard"/>
-                </Grid>
-                <Grid xs ={12} sm={12} md={12} lg={12}>
-                    <Typography variant="h4" >
-                        Email
-                    </Typography>
-                    <TextField 
-                    name="emailAddress"
-                    value={formData.emailAddress}
-                    onChange={handleInputChange}
-                    InputProps={{disableUnderline: true, style: {paddingLeft: 8} }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
-                    variant="standard"
-                    error={Boolean(emailError)}
-                    helperText={emailError}
-                    required/>
-                </Grid>
-            </Grid>
-            {/* This is column 2 */}
-            
-            <Grid container spacing={4} direction='column' alignItems='flex-start'  paddingBottom='13%'>
-                <Grid xs ={12} sm={12} md={12} lg={12}>
-                    <Typography variant="h4" >
-                        Last Name
-                    </Typography>
-                    <TextField 
-                    name="lastName"
-                    value={formData.lastName}
-                    onChange={handleInputChange}
-                    InputProps={{disableUnderline: true, style: {paddingLeft: 8}  }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
-                    variant="standard"
-                    required/>
-                </Grid>
-                <Grid xs ={12} sm={12} md={12} lg={12}>
-                    <Typography variant="h4">
-                       Role
-                    </Typography>
-                    <Select
-                        name="role"
-                        value={formData.role}
-                        onChange={handleSelectChange}
-                        sx={{ borderRadius: '20px',  width: "190px", backgroundColor: "#FFFFFF", outlineColor: "#000000", height: '32px'}}
-                        required
-                    >
-                    <MenuItem value={'Coordinator'}>Coordinator</MenuItem>
-                    <MenuItem value={'Full-time Staff'}>Full-time Staff</MenuItem>
-                    <MenuItem value={'Part-time Staff'}>Part-time Staff</MenuItem>
-                    <MenuItem value={'Relief Staff'}>Relief Staff</MenuItem>
-                </Select>
-                </Grid>
-                <Grid xs ={12} sm={12} md={12} lg={12}>
-                    <Typography variant="h4">
-                        Phone Number
-                    </Typography>
-                      <PhoneInput
-                        international
-                        countryCallingCodeEditable={false}
-                        value={phoneNumber}
-                        onChange={handlePhoneNumberChange}
-                        defaultCountry="US"
-                        style={{ width: '100%', height: '40px', backgroundColor: '#FFFFFF', borderRadius: '10px' }}
-                        required
-                      />
-                </Grid>
-                <Grid xs ={12} sm={12} md={12} lg={12} container justifyContent='flex-end' textAlign ='center' paddingTop='15%' paddingRight='15%' paddingLeft='20%' sx = {{ display:'flex', justifyContent:'center'}}>
-                    <Button type="submit" sx={{ paddingLeft: '10%', textIndent:'5.5px', paddingRight:'10%', borderRadius:'25px', backgroundColor: theme.palette.secondary.main, '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">Save Changes</Button>
-                </Grid>
-                </Grid>    
-                </Grid> 
-                </form>                           
-                </Box>
-           
+            <form onSubmit={handleSubmit}>
+            <Grid container spacing={5} columnSpacing={{xs: 10, sm:80, md:5, lg:5}} justify-content='flex-start' alignItems='flex-start' columns={12}  margin={{xs: 1, sm: 2, md: 3, lg: 4}}>
+
+              {/* Outer Grid, 2 sections, left is profile, right are fields */}
+              <Grid container spacing={4} direction='row' justifyContent='flex-start' alignItems='flex-start'>
+
+
+
+                      {/* PROFILE SECTION */}
+                      <Grid container spacing={4} direction='column' justifyContent='flex-start' alignItems='flex-start'>
+
+                          <Grid xs={12} sm={12} md={12} lg={12} sx={{ justifyContent:'flex-start', alignItems:'flex-start', display: 'flex'}}>
+                              <Avatar alt="Remy Sharp" sx={{ width: 150, height: 150 }} />
+                          </Grid>
+
+                          <Grid xs={12} sm={12} md={12} lg={12} textAlign={'center'}>
+              
+                              <Button variant="outlined" sx={{ textIndent: '2px' ,borderRadius: '20px',  borderColor: theme.palette.primary.main, color: "#000000", '&:hover': {borderColor: theme.palette.primary.main}, textTransform: 'none', paddingRight: '10%'}}>
+                                  <Image src={UploadImage} alt="upload image" width={17} height={17} />
+                                  Upload Picture
+                              </Button>
+                              
+                          </Grid>
+
+                      </Grid>
+
+
+                      {/* FIELDS SECTION */}
+                      <Grid container spacing={3} direction='column' justifyContent='flex-start' alignItems='flex-start'>
+
+                          {/* First and Last Name Row */}
+                          <Grid container spacing={4} direction='row' justifyContent='flex-start' alignItems='flex-start'>
+                              {/* First Name */}
+                              <Grid xs ={6} sm={6} md={6} lg={6} justifyContent ={'flex-start'}>
+                                  <Typography variant="h4">
+                                      First Name
+                                  </Typography>
+                                  <TextField 
+                                      name="firstName"
+                                      value={formData.firstName}
+                                      onChange={handleInputChange} 
+                                      InputProps={{disableUnderline: true, style: {paddingLeft: 8} }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
+                                      variant="standard"
+                                      required/>
+                              </Grid>
+                              {/* Last Name */}
+                              <Grid xs ={6} sm={6} md={6} lg={6}>
+                                  <Typography variant="h4" >
+                                      Last Name
+                                  </Typography>
+                                  <TextField 
+                                  name="lastName"
+                                  value={formData.lastName}
+                                  onChange={handleInputChange}
+                                  InputProps={{disableUnderline: true, style: {paddingLeft: 8}  }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
+                                  variant="standard"
+                                  required/>
+                              </Grid>
+      
+                          </Grid>
+
+                          {/* Pronouns and Role Row */}
+                          <Grid container spacing={6} direction='row' justifyContent='flex-start' alignItems='flex-start'>
+                                {/* Pronouns */}
+                                <Grid direction='row' xs={6} sm={6} md={6} lg={6}>
+                                    <Typography variant="h4" >
+                                        Pronouns
+                                    </Typography>
+                                    <TextField
+                                    name="pronouns"
+                                    value={formData.pronouns}
+                                    onChange={handleInputChange} 
+                                    InputProps={{disableUnderline: true, style: {paddingLeft: 8}}} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
+                                    variant="standard"/>
+                                </Grid>
+                                {/* Role */}
+                                <Grid xs={6} sm={6} md={6} lg={6}>
+                                    <Typography variant="h4">
+                                      Role
+                                    </Typography>
+                                    <Select
+                                        name="role"
+                                        value={formData.role}
+                                        onChange={handleSelectChange}
+                                        sx={{ borderRadius: '20px',  width: "190px", backgroundColor: "#FFFFFF", outlineColor: "#000000", height: '32px'}}
+                                        required
+                                    >
+                                        <MenuItem value={'Coordinator'}>Coordinator</MenuItem>
+                                        <MenuItem value={'Full-time Staff'}>Full-time Staff</MenuItem>
+                                        <MenuItem value={'Part-time Staff'}>Part-time Staff</MenuItem>
+                                        <MenuItem value={'Relief Staff'}>Relief Staff</MenuItem>
+                                    </Select>
+                                </Grid>
+                          </Grid>
+
+                          {/* Email and Phone Number Row */}
+                          <Grid container spacing={5} direction='row' justifyContent='flex-start' alignItems='flex-start'>
+                                {/* Email */}
+                                <Grid xs={6} sm={6} md={6} lg={6}>
+                                    <Typography variant="h4" >
+                                        Email
+                                    </Typography>
+                                    <TextField 
+                                    name="emailAddress"
+                                    value={formData.emailAddress}
+                                    onChange={handleInputChange}
+                                    InputProps={{disableUnderline: true, style: {paddingLeft: 8} }} sx={{backgroundColor: '#FFFFFF', borderRadius:'10px'}} 
+                                    variant="standard"
+                                    error={Boolean(emailError)}
+                                    helperText={emailError}
+                                    required/>
+                                </Grid>
+                                {/* Phone Number */}
+                                <Grid xs={6} sm={6} md={6} lg={6}>
+                                    <Typography variant="h4">
+                                        Phone Number
+                                    </Typography>
+                                    <PhoneInput
+                                        international
+                                        countryCallingCodeEditable={false}
+                                        value={phoneNumber}
+                                        onChange={handlePhoneNumberChange}
+                                        defaultCountry="US"
+                                        style={{ width: '100%', height: '40px', backgroundColor: '#FFFFFF', borderRadius: '10px' }}
+                                        required />
+                                  </Grid>
+                          </Grid>
+                          {/* Submit Row */}
+                          <Grid container spacing={4} direction='row' sx={{paddingLeft: '70%'}}>
+                              <Grid xs={12} sm={12} md={12} lg={12}>
+                                    <Button type="submit" sx={{ width: '130%', paddingLeft: '10%', textIndent:'5.5px', borderRadius:'25px', backgroundColor: theme.palette.secondary.main, '&:hover': {backgroundColor:"#89B839"}, textTransform: 'none'}}variant="contained">Save Changes</Button>
+                              </Grid>
+                          </Grid>
+
+                      </Grid>
+              </Grid>
+            </Grid> 
+            </form>                           
             </Box>
-            </Modal>
-            <Snackbar open={openSnack} autoHideDuration={6000} onClose={handleCloseSnack}>
+          </Box>
+        </Modal>
+
+        <Snackbar open={openSnack} autoHideDuration={6000} onClose={handleCloseSnack}>
                 <Alert
                 onClose={handleCloseSnack}
                 severity="success"


### PR DESCRIPTION
**Developer**: Pam
**Dates**: 4/20/2024
**Time Spent:** 1 hour

**Summary:**
During bug bash, we got a strong comment pertaining to the progression of filling out a new employee in the employee manage profiles page-- that the progression felt very unnatural when hitting the TAB key.

The modal was previously constructed by columns, so when you would fill in a textbox and hit TAB, you would go FirstName > Pronouns > Email > Lastname > Role > Phone Number. I realized the problem was with how the order of the components were implemented, so I went ahead and re-arranged the order and cleaned up the grid, doing my best to maintain the style that was previously in-place. Now when filling out fields, it feels a lot more natural and we can go in the order we would expect: FirstName > LastName > Pronouns > Role > Email > Phone Number.

**Screenshots** [desktop]
![image](https://github.com/JumboCode/casa-myrna/assets/79951993/a722b9e2-0cdb-4d12-bd1d-702646e3b3cf)


Reflection: 

This was a thing that was always in the back of my mind and I hadn't seen a ticket for it. I had spare time and really wanted to see if it was as easy as I was thinking it was in my head, and I was happy to say it was! Grid V2 is so nice, it was so intuitive and worked exactly the way I had anticipated, making this a quick and easy fix. The button shrank as a result, but I modified the styling and padding to bring it back, I feel like I can finally sleep now :)

I also noticed this looks different than the new design, I just hope this modification makes it easier for the next people who work on it, I also commented it out for the grid to make sense for future people :)

