### PR TITLE
#7 Get rid of "cancel shift" button on Add Shift Modal (last ticket! :D)

### DIFF
--- a/app/components/CalendarModalButton.tsx
+++ b/app/components/CalendarModalButton.tsx
@@ -30,7 +30,7 @@ const style = {
     xs: "80%",
   },
   height: {
-    lg: 500,
+    lg: 520,
     xs: "70%",
   },
   bgcolor: "#ffffff",
@@ -568,25 +568,8 @@ const CalendarModalButton: FC<any> = ({ callback }) => {
                       justifyContent: "center",
                     }}
                   >
-                    <Grid item xs={3}>
-                      <Button
-                        type="submit"
-                        sx={{
-                          paddingLeft: "10%",
-                          textIndent: "5.5px",
-                          paddingRight: "10%",
-                          borderRadius: "10px",
-                          backgroundColor: theme.palette.primary.main,
-                          "&:hover": { backgroundColor: "#2E0057" },
-                          textTransform: "none",
-                        }}
-                        variant="contained"
-                      >
-                        Cancel Shift
-                      </Button>
-                    </Grid>
                     {/* ASSIGN SHIFT CONFIRMATION BUTTON (where we post shift) */}
-                    <Grid item xs={3}>
+                    <Grid item xs={3} >
                       <Button
                         type="submit"
                         variant="contained"


### PR DESCRIPTION
Developer: Jiyoon and Eliana
Dates: April 24th
Time spent: 30 minutes
Summary: Deleted the Cancel Shift button on the Add Shift Modal

Testing:
<img width="1440" alt="Screenshot 2024-04-24 at 5 29 41 PM" src="https://github.com/JumboCode/casa-myrna/assets/46614509/96c85650-121c-4203-8fd4-d7f5264c572a">