### PR TITLE
Rendered Cal on /page.tsx to simulate home page as calendar page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,10 +7,11 @@ import Sidebar from "./components/Sidebar";
 import "./globals.css";
 import theme from './theme';
 import { BrowserRouter as Router, useNavigate } from 'react-router-dom';
+import Cal from "./components/Calendar"
 
 
 const Main = () => {
-  return (<ThemeProvider theme={theme}><Router><Sidebar currentPageComponent={Typography}/></Router></ThemeProvider>)
+  return (<ThemeProvider theme={theme}><Router><Sidebar currentPageComponent={Cal}/></Router></ThemeProvider>)
 };
 
 export default Main;


### PR DESCRIPTION
Developer: Pam and Carly
Dates: April 28th 2024
Time spent: 1 hour
Summary: Simulated the calendar page as the home page upon login

Testing Desktop:
![image](https://github.com/JumboCode/casa-myrna/assets/79951993/6ffdae81-8eec-4848-a64d-2f58f30a1a88)


Testing Mobile:
![image](https://github.com/JumboCode/casa-myrna/assets/79951993/cf9be32c-158f-4cdd-a9a9-169009dfde01)



Reflection: We played around with the middleware.tsx and making an index.tsx page and weren't sure how to use Redirecting to move the user to the calendar page, so we settled on making calendar render on the the "/" home page. This works just fine and we tested everything still works.